### PR TITLE
Fix interaction with gopass

### DIFF
--- a/minilock-cli/main.go
+++ b/minilock-cli/main.go
@@ -7,11 +7,12 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
+
 	"github.com/alecthomas/kingpin"
 	"github.com/cathalgarvey/go-minilock"
 	"github.com/cathalgarvey/go-minilock/taber"
 	"github.com/howeyc/gopass"
-	"io/ioutil"
 )
 
 var (
@@ -114,6 +115,10 @@ func getPass() string {
 		return *PassPhrase
 	} else {
 		fmt.Print("Enter passphrase: ")
-		return string(gopass.GetPasswd())
+		p, err := gopass.GetPasswd()
+		if err != nil {
+			panic(err)
+		}
+		return string(p)
 	}
 }


### PR DESCRIPTION
An update to [gopass](https://github.com/howeyc/gopass)'s API has changed the `GetPasswd` methods return values. They have changed from `byte[]` to `byte[], error`.
This change allows the minilock-cli to be installed correctly with `go get -u`